### PR TITLE
fix template with an if clause, because service does not start

### DIFF
--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -333,7 +333,16 @@ hostname = "<%= @hostname %>"
   ### optional  extra tags  following the  template.  Multiple  tags should  be
   ### separated by  commas and no spaces  similar to the line  protocol format.
   ### There can be only one default template.
-  templates = [ <%= @graphite_templates.map{ |template| "\"#{template}\"" }.join(',') %> ]
+  <% if @graphite_enable == true %>
+    templates = [ <%= @graphite_templates.map{ |template| "\"#{template}\"" }.join(',') %> ]
+  <% else %>
+    # templates = [
+    #   "*.app env.service.resource.measurement",
+    #   # Default template
+    #   "server.*",
+    # ]
+  <% end %>
+
 
 ###
 ### [collectd]


### PR DESCRIPTION
Thanks for your puppet module. I tested it and my service does not start on Debian 9.11. It is showing a template error. I added a if clause for asking, if graphite is enabled or not. On that, I added the default parameter after installing it (from the package itself).

Hope you are merging it :)

Have a nice day