### PR TITLE
Bugfix: double-quote values of data cache params

### DIFF
--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -64,21 +64,21 @@ hostname = "<%= @hostname %>"
 
   # CacheMaxMemorySize is the maximum size a shard's cache can
   # reach before it starts rejecting writes.
-  cache-max-memory-size =  <%= @cache_max_memory_size %>
+  cache-max-memory-size =  "<%= @cache_max_memory_size %>"
 
   # CacheSnapshotMemorySize is the size at which the engine will
   # snapshot the cache and write it to a TSM file, freeing up memory
-  cache-snapshot-memory-size = <%= @cache_snapshot_memory_size %>
+  cache-snapshot-memory-size = "<%= @cache_snapshot_memory_size %>"
 
   # CacheSnapshotWriteColdDuration is the length of time at
   # which the engine will snapshot the cache and write it to
   # a new TSM file if the shard hasn't received writes or deletes
-  cache-snapshot-write-cold-duration = <%= @cache_snapshot_write_cold_duration %>
+  cache-snapshot-write-cold-duration = "<%= @cache_snapshot_write_cold_duration %>"
 
   # CompactFullWriteColdDuration is the duration at which the engine
   # will compact all TSM files in a shard if it hasn't received a
   # write or delete
-  compact-full-write-cold-duration = <%= @compact_full_write_old_duration %>
+  compact-full-write-cold-duration = "<%= @compact_full_write_old_duration %>"
 
   # The maximum  series allowed per  database before writes are  dropped.  This
   # limit  can prevent  high cardinality  issues at  the database  level.  This


### PR DESCRIPTION
Data cache params (TSM engine config values) can use suffixes:
 - k, m, g for memory sizes
 - time interval suffixes for durations

They therefore need to be in double quotes in influxdb.conf

Fixes veepee-puppet/puppet-influxdb issue #20 
