### PR TITLE
Updates for more recent Debian and Ubuntu packages

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -13,7 +13,7 @@ class influxdb::repos (
   case $::operatingsystem {
     /(?i:debian|devuan|ubuntu)/: {
       case $::lsbdistcodename {
-        /(buster|n\/a)/   : {
+        /(bullseye|n\/a)/   : {
           if !defined(Class['apt']) {
             include apt
           }
@@ -21,7 +21,7 @@ class influxdb::repos (
           apt::source { 'influxdb':
             ensure   => present,
             location => $apt_location,
-            release  => 'jessie',
+            release  => 'buster',
             repos    => 'stable',
             key      => $apt_key,
             notify   => Exec['apt_update']


### PR DESCRIPTION
Two commits:
- one bumps the supported Debian release now InfluxData have official packages for Buster
- the other allows use of the distro-packaged version by setting manage_repo to false and split_client_package to true.  Default is not to do this but carry on using the vendor packages.