### PR TITLE
Mark compatible with puppetlabs/apt < 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.5.1 <= 7.1.0"
+      "version_requirement": ">= 4.5.1 <= 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This makes it compatible with the current latest version.